### PR TITLE
fix(Admin): Resolve strict mode error on Manage Agents page

### DIFF
--- a/hotel-management-frontend/src/pages/AdminPages/AdminManageAgentsPage.js
+++ b/hotel-management-frontend/src/pages/AdminPages/AdminManageAgentsPage.js
@@ -1,23 +1,27 @@
 import React, { useState, useEffect } from 'react';
-import { getAllUsers, adminUpdateUserRole, adminResetUserPassword } from '../../services/authService';
+import { getAllUsers, adminUpdateUserRole, adminResetUserPassword, getCurrentUser } from '../../services/authService';
 import './AdminPages.css'; // Shared admin styles
 
 const AdminManageAgentsPage = () => {
   const [users, setUsers] = useState([]);
-  // const [agents, setAgents] = useState([]); // We will display all users and manage roles
+  const [currentAdmin, setCurrentAdmin] = useState(null); // State for current admin user
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [feedback, setFeedback] = useState('');
 
-  const fetchAllUsers = async () => {
+  const fetchData = async () => {
     setLoading(true);
     setError('');
     try {
-      const allUsers = await getAllUsers();
-      setUsers(allUsers);
-      // setAgents(allUsers.filter(user => user.role !== 'admin')); // Filtered out admin for agent management
+      // Fetch both all users and the current admin user concurrently
+      const [allUsersResponse, currentAdminResponse] = await Promise.all([
+        getAllUsers(),
+        getCurrentUser()
+      ]);
+      setUsers(allUsersResponse);
+      setCurrentAdmin(currentAdminResponse);
     } catch (err) {
-      setError("Failed to fetch users.");
+      setError("Failed to fetch users or current admin details.");
       console.error(err);
     } finally {
       setLoading(false);
@@ -25,19 +29,26 @@ const AdminManageAgentsPage = () => {
   };
 
   useEffect(() => {
-    fetchAllUsers();
+    fetchData();
   }, []);
 
   const handleRoleChange = async (userId, newRole) => {
     setFeedback(''); setError('');
     if (!window.confirm(\`Are you sure you want to change this user's role to \${newRole}?\`)) return;
+
+    // Prevent changing the role of the current admin if they are the only admin
+    if (currentAdmin && userId === currentAdmin.id && currentAdmin.role === 'admin' && users.filter(u => u.role === 'admin').length <= 1 && newRole !== 'admin') {
+        setError("Cannot change the role of the sole administrator to a non-admin role.");
+        return;
+    }
+
     try {
       await adminUpdateUserRole(userId, newRole);
       setFeedback(\`User role updated successfully. New role: \${newRole}\`);
-      fetchAllUsers(); // Re-fetch to show updated role
+      fetchData(); // Re-fetch all data to show updated roles and potentially currentAdmin if changed
     } catch (err) {
       setError(err.message || "Failed to update role.");
-      setFeedback(''); // Clear feedback if error
+      setFeedback('');
     }
   };
 
@@ -49,12 +60,11 @@ const AdminManageAgentsPage = () => {
       setFeedback(result.message);
     } catch (err) {
       setError(err.message || "Failed to reset password.");
-      setFeedback(''); // Clear feedback if error
+      setFeedback('');
     }
   };
 
   if (loading) return <div className="admin-page"><p>Loading users...</p></div>;
-
 
   return (
     <div className="admin-page">
@@ -64,8 +74,6 @@ const AdminManageAgentsPage = () => {
       <main className="admin-content">
         {error && <p className="error-message">{error}</p>}
         {feedback && <p className={error ? "error-message" : "success-message"}>{feedback}</p>}
-
-        {/* TODO: Add form to create/invite new agent user with a specific role */}
 
         <h3>Users List</h3>
         <table className="admin-table">
@@ -78,29 +86,43 @@ const AdminManageAgentsPage = () => {
             </tr>
           </thead>
           <tbody>
-            {users.map(user => (
-              <tr key={user.id}>
-                <td>{user.name}</td>
-                <td>{user.email}</td>
-                <td>{user.role}</td>
-                <td className="actions">
-                  <select
-                    value={user.role}
-                    onChange={(e) => handleRoleChange(user.id, e.target.value)}
-                    // Prevent admin from easily changing their own role or another admin's role via this UI for safety
-                    disabled={user.role === 'admin' && users.filter(u => u.role ==='admin').length <=1 && user.id === getAllUsers.caller?.id /*This is pseudo check, real check needed*/}
-                  >
-                    <option value="client">Client</option>
-                    <option value="agent">Agent</option>
-                    {/* Admin role should be managed more carefully, perhaps not from a simple dropdown */}
-                    <option value="admin" disabled={user.role !== 'admin'}>Admin</option>
-                  </select>
-                  <button onClick={() => handlePasswordReset(user.id)} className="edit-btn" style={{marginLeft: '10px'}}>
-                    Reset Password (Mock)
-                  </button>
-                </td>
-              </tr>
-            ))}
+            {users.map(user => {
+              // Determine if the role select should be disabled for this user
+              let isRoleSelectDisabled = false;
+              // Logic to disable changing role of the sole admin
+              if (user.role === 'admin' && currentAdmin && user.id === currentAdmin.id && users.filter(u => u.role === 'admin').length <= 1) {
+                  isRoleSelectDisabled = true;
+              }
+
+              return (
+                <tr key={user.id}>
+                  <td>{user.name}</td>
+                  <td>{user.email}</td>
+                  <td>{user.role}</td>
+                  <td className="actions">
+                    <select
+                      value={user.role}
+                      onChange={(e) => handleRoleChange(user.id, e.target.value)}
+                      disabled={isRoleSelectDisabled} // Disables select if true
+                      aria-label={`Change role for ${user.name}`}
+                    >
+                      <option value="client">Client</option>
+                      <option value="agent">Agent</option>
+                      {/* Admin role can only be selected if user is already admin, and select is not disabled */}
+                      <option value="admin" disabled={user.role !== 'admin' && !isRoleSelectDisabled}>Admin</option>
+                    </select>
+                    <button
+                      onClick={() => handlePasswordReset(user.id)}
+                      className="edit-btn"
+                      style={{marginLeft: '10px'}}
+                      aria-label={`Reset password for ${user.name}`}
+                    >
+                      Reset Password (Mock)
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
         {users.length === 0 && !loading && <p>No users found.</p>}


### PR DESCRIPTION
Corrected a TypeError on the `/admin/manage-agents` page caused by accessing the deprecated `Function.prototype.caller` property in a `disabled` condition for a select element. This access attempt violated JavaScript's strict mode, in which React development builds run.

The fix involves:
1.  Removing the reference to `.caller`.
2.  Introducing state in `AdminManageAgentsPage.js` to store the `currentAdmin` user object, fetched via `getCurrentUser()`.
3.  Updating the logic for disabling the role selection dropdown to correctly check if the user being rendered is the sole administrator and is the same as the `currentAdmin`. This prevents a sole admin from inadvertently changing their own role.

The page should now load without runtime errors and provide a safer experience for managing user roles.